### PR TITLE
Fix quotation mark

### DIFF
--- a/41471-h/41471-h.htm
+++ b/41471-h/41471-h.htm
@@ -10046,7 +10046,7 @@ seems likely, how can they withdraw from this service
 without leave? Would you not be angry if one of your
 servants were to do it?&rsquo;</p>
 
-<p>&ldquo;&lsquo;True,&rsquo; said Cebes, &ldquo;&lsquo;but if we are the servants of the
+<p>&ldquo;&lsquo;True,&rsquo; said Cebes, &lsquo;but if we are the servants of the
 gods, and therefore in the best guardianship, should we not
 be sorry to quit it? If so, is it not for the foolish to desire
 death and for the wise to regret it?&rsquo; &lsquo;You are right,&rsquo; replied


### PR DESCRIPTION
Remove unneeded opening double quotation mark. This fix was previously made in the plain text version.